### PR TITLE
feat: Hash user passwords

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "bcryptjs": "^3.0.3"
             },
             "devDependencies": {
-                "@types/bcryptjs": "^2.4.6",
                 "@types/node": "^25.3.5",
                 "@typescript-eslint/eslint-plugin": "^8.56.1",
                 "@typescript-eslint/parser": "^8.56.1",
@@ -967,13 +966,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@types/bcryptjs": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
-            "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
             "name": "omni-nexus",
             "version": "1.0.0",
             "license": "ISC",
+            "dependencies": {
+                "bcryptjs": "^3.0.3"
+            },
             "devDependencies": {
+                "@types/bcryptjs": "^2.4.6",
                 "@types/node": "^25.3.5",
                 "@typescript-eslint/eslint-plugin": "^8.56.1",
                 "@typescript-eslint/parser": "^8.56.1",
@@ -964,6 +968,13 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/bcryptjs": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+            "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1419,6 +1430,15 @@
                 "node": "18 || 20 || >=22"
             }
         },
+        "node_modules/bcryptjs": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+            "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+            "license": "BSD-3-Clause",
+            "bin": {
+                "bcrypt": "bin/bcrypt"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
@@ -1853,9 +1873,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+            "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
             "dev": true,
             "license": "ISC"
         },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "license": "ISC",
     "description": "",
     "devDependencies": {
-        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^25.3.5",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "license": "ISC",
     "description": "",
     "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^25.3.5",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
@@ -22,5 +23,8 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
+    },
+    "dependencies": {
+        "bcryptjs": "^3.0.3"
     }
 }

--- a/src/users/bcrypt-password-hasher.ts
+++ b/src/users/bcrypt-password-hasher.ts
@@ -1,0 +1,14 @@
+import bcrypt from 'bcryptjs';
+import type { PasswordHasher } from './password-hasher.js';
+
+export class BcryptPasswordHasher implements PasswordHasher {
+    private readonly saltRounds: number;
+
+    public constructor(saltRounds = 10) {
+        this.saltRounds = saltRounds;
+    }
+
+    public async hash(plainPassword: string): Promise<string> {
+        return bcrypt.hash(plainPassword, this.saltRounds);
+    }
+}

--- a/src/users/bcrypt-password-hasher.ts
+++ b/src/users/bcrypt-password-hasher.ts
@@ -5,6 +5,9 @@ export class BcryptPasswordHasher implements PasswordHasher {
     private readonly saltRounds: number;
 
     public constructor(saltRounds = 10) {
+        if (!Number.isInteger(saltRounds) || saltRounds < 10) {
+            throw new Error('saltRounds must be an integer >= 10');
+        }
         this.saltRounds = saltRounds;
     }
 

--- a/src/users/create-user.usecase.test.ts
+++ b/src/users/create-user.usecase.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { CreateUserUseCase } from './create-user.usecase.js';
-import { User, type CreateUserParams } from './user.entity.js';
+import {
+    CreateUserUseCase,
+    type RegisterUserInput,
+} from './create-user.usecase.js';
+import { User } from './user.entity.js';
 import type { UserRepository } from './user.repository.js';
+import type { PasswordHasher } from './password-hasher.js';
 import { DomainError } from '../common/errors/domain.error.js';
 
-// We need a fake/mock repository for the usecase to talk to
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
 class MockUserRepository implements UserRepository {
     public savedUsers: User[] = [];
 
@@ -29,30 +36,43 @@ class MockUserRepository implements UserRepository {
     }
 }
 
+// A thin helper so every test gets a fresh, consistent mock hasher.
+const makeMockHasher = (resolvedHash = 'hashed_password'): PasswordHasher => ({
+    hash: vi.fn().mockResolvedValue(resolvedHash),
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('CreateUserUseCase', () => {
     beforeEach(() => {
         vi.resetAllMocks();
     });
 
-    it('should create and save a new user', async () => {
-        // 1. Arrange: Setup the dependencies
+    it('should hash the plain password and save the user', async () => {
         const mockRepo = new MockUserRepository();
-        const useCase = new CreateUserUseCase(mockRepo);
+        const mockHasher = makeMockHasher('super_hashed');
+        const useCase = new CreateUserUseCase(mockRepo, mockHasher);
 
-        const params: CreateUserParams = {
+        const input: RegisterUserInput = {
             id: '1',
             username: 'username',
-            passwordHash: 'passwordHash',
+            password: 'plainPassword',
             email: 'test@email.com',
         };
 
-        // 2. Act: Execute the workflow
-        const createdUser = await useCase.execute(params);
+        const createdUser = await useCase.execute(input);
 
-        // 3. Assert: Verify side-effects (saved to DB)
+        // Verify the hasher was called with the plain-text password
+        expect(mockHasher.hash).toHaveBeenCalledWith('plainPassword');
+        expect(mockHasher.hash).toHaveBeenCalledTimes(1);
+
+        // Verify the entity stores the hash, not the plain password
+        expect(createdUser.passwordHash).toBe('super_hashed');
+
+        // Verify side-effects and returned entity
         expect(mockRepo.savedUsers.length).toBe(1);
-
-        // 4. Assert: Verify the returned entity
         expect(createdUser).toBeDefined();
         expect(createdUser.id).toBe('1');
         expect(createdUser.username).toBe('username');
@@ -62,29 +82,30 @@ describe('CreateUserUseCase', () => {
 
     it('should throw DomainError if email is already taken', async () => {
         const mockRepo = new MockUserRepository();
-        const useCase = new CreateUserUseCase(mockRepo);
+        const mockHasher = makeMockHasher();
+        const useCase = new CreateUserUseCase(mockRepo, mockHasher);
 
-        const params: CreateUserParams = {
+        const input: RegisterUserInput = {
             id: '1',
             username: 'originalUser',
-            passwordHash: 'hash',
+            password: 'password123',
             email: 'duplicate@email.com',
         };
 
         // Pre-fill the repository
-        await useCase.execute(params);
+        await useCase.execute(input);
 
         // Spy on save AFTER pre-fill so we only track the duplicate attempt
         const saveSpy = vi.spyOn(mockRepo, 'save');
 
-        const duplicateParams: CreateUserParams = {
+        const duplicateInput: RegisterUserInput = {
             id: '2',
             username: 'newUser',
-            passwordHash: 'hash2',
+            password: 'password456',
             email: 'duplicate@email.com',
         };
 
-        await expect(useCase.execute(duplicateParams)).rejects.toThrow(
+        await expect(useCase.execute(duplicateInput)).rejects.toThrow(
             DomainError
         );
         expect(mockRepo.savedUsers.length).toBe(1);
@@ -93,29 +114,30 @@ describe('CreateUserUseCase', () => {
 
     it('should throw DomainError if username is already taken', async () => {
         const mockRepo = new MockUserRepository();
-        const useCase = new CreateUserUseCase(mockRepo);
+        const mockHasher = makeMockHasher();
+        const useCase = new CreateUserUseCase(mockRepo, mockHasher);
 
-        const params: CreateUserParams = {
+        const input: RegisterUserInput = {
             id: '1',
             username: 'duplicateUser',
-            passwordHash: 'hash',
+            password: 'password123',
             email: 'first@email.com',
         };
 
         // Pre-fill
-        await useCase.execute(params);
+        await useCase.execute(input);
 
         // Spy on save AFTER pre-fill so we only track the duplicate attempt
         const saveSpy = vi.spyOn(mockRepo, 'save');
 
-        const duplicateParams: CreateUserParams = {
+        const duplicateInput: RegisterUserInput = {
             id: '2',
             username: 'duplicateUser',
-            passwordHash: 'hash2',
+            password: 'password456',
             email: 'second@email.com',
         };
 
-        await expect(useCase.execute(duplicateParams)).rejects.toThrow(
+        await expect(useCase.execute(duplicateInput)).rejects.toThrow(
             DomainError
         );
         expect(mockRepo.savedUsers.length).toBe(1);
@@ -124,33 +146,31 @@ describe('CreateUserUseCase', () => {
 
     it('should throw DomainError from repository save if pre-checks were bypassed (race condition simulation)', async () => {
         const mockRepo = new MockUserRepository();
-        const useCase = new CreateUserUseCase(mockRepo);
+        const mockHasher = makeMockHasher();
+        const useCase = new CreateUserUseCase(mockRepo, mockHasher);
 
-        const params: CreateUserParams = {
+        // Directly push to repository to simulate a concurrent save that happened
+        // after our pre-checks but before our own save.
+        const existingUser = new User({
             id: '1',
             username: 'user1',
             passwordHash: 'hash',
             email: 'user1@email.com',
-        };
-
-        // Directly push to repository to simulate a concurrent save that happened after our pre-checks
-        // but before our save.
-        const existingUser = new User(params);
+        });
         mockRepo.savedUsers.push(existingUser);
 
-        const newParams: CreateUserParams = {
+        const newInput: RegisterUserInput = {
             id: '2',
             username: 'user2',
-            passwordHash: 'hash',
+            password: 'password',
             email: 'user1@email.com', // Duplicate email
         };
 
-        // The usecase will pass pre-checks if we mock findByEmail to return null,
-        // but save() should still catch it.
+        // Bypass the use case pre-checks to simulate the race
         vi.spyOn(mockRepo, 'findByEmail').mockResolvedValue(null);
         vi.spyOn(mockRepo, 'findByUsername').mockResolvedValue(null);
 
-        await expect(useCase.execute(newParams)).rejects.toThrow(
+        await expect(useCase.execute(newInput)).rejects.toThrow(
             `Email 'user1@email.com' is already taken.`
         );
         expect(mockRepo.savedUsers.length).toBe(1);

--- a/src/users/create-user.usecase.ts
+++ b/src/users/create-user.usecase.ts
@@ -1,22 +1,49 @@
-import { User, type CreateUserParams } from './user.entity.js';
+import { User } from './user.entity.js';
 import { type UserRepository } from './user.repository.js';
+import { type PasswordHasher } from './password-hasher.js';
 import { DomainError } from '../common/errors/domain.error.js';
 
+export interface RegisterUserInput {
+    id: string;
+    username: string;
+    email: string;
+    password: string; // plain-text — will be hashed before the entity is created
+}
+
 export class CreateUserUseCase {
-    public constructor(private readonly userRepository: UserRepository) {}
+    public constructor(
+        private readonly userRepository: UserRepository,
+        private readonly passwordHasher: PasswordHasher
+    ) {}
 
-    public async execute(params: CreateUserParams): Promise<User> {
-        const existingEmail = await this.userRepository.findByEmail(params.email);
+    public async execute(input: RegisterUserInput): Promise<User> {
+        const existingEmail = await this.userRepository.findByEmail(
+            input.email
+        );
         if (existingEmail) {
-            throw new DomainError(`Email '${params.email}' is already taken.`);
+            throw new DomainError(`Email '${input.email}' is already taken.`);
         }
 
-        const existingUsername = await this.userRepository.findByUsername(params.username);
+        const existingUsername = await this.userRepository.findByUsername(
+            input.username
+        );
         if (existingUsername) {
-            throw new DomainError(`Username '${params.username}' is already taken.`);
+            throw new DomainError(
+                `Username '${input.username}' is already taken.`
+            );
         }
 
-        const user = new User(params);
+        // Hash only after the fast-fail pre-checks pass — no point doing
+        // expensive crypto if we're going to throw anyway.
+        const passwordHash = await this.passwordHasher.hash(input.password);
+
+        const user = new User({
+            id: input.id,
+            username: input.username,
+            email: input.email,
+            passwordHash,
+        });
+
         await this.userRepository.save(user);
         return user;
     }

--- a/src/users/create-user.usecase.ts
+++ b/src/users/create-user.usecase.ts
@@ -17,16 +17,15 @@ export class CreateUserUseCase {
     ) {}
 
     public async execute(input: RegisterUserInput): Promise<User> {
-        const existingEmail = await this.userRepository.findByEmail(
-            input.email
-        );
+        const [existingEmail, existingUsername] = await Promise.all([
+            this.userRepository.findByEmail(input.email),
+            this.userRepository.findByUsername(input.username),
+        ]);
+
         if (existingEmail) {
             throw new DomainError(`Email '${input.email}' is already taken.`);
         }
 
-        const existingUsername = await this.userRepository.findByUsername(
-            input.username
-        );
         if (existingUsername) {
             throw new DomainError(
                 `Username '${input.username}' is already taken.`

--- a/src/users/password-hasher.ts
+++ b/src/users/password-hasher.ts
@@ -1,0 +1,3 @@
+export interface PasswordHasher {
+    hash(plainPassword: string): Promise<string>;
+}


### PR DESCRIPTION
## Summary

Closes #4

Implements secure password hashing before persisting a User entity, following Clean Architecture principles.

## Changes

### New files
- src/users/password-hasher.ts  PasswordHasher interface (domain layer). The use case depends on this abstraction, not on any specific library.
- src/users/bcrypt-password-hasher.ts  BcryptPasswordHasher adapter (infrastructure layer) using cryptjs.

### Updated files
- src/users/create-user.usecase.ts
  - Introduced RegisterUserInput type with a plain password field (replaces direct passwordHash input).
  - Injected PasswordHasher as a second constructor dependency.
  - Password is hashed **after** the duplicate pre-checks so no expensive crypto is done on requests that will fail anyway.
- src/users/create-user.usecase.test.ts
  - All tests updated to use RegisterUserInput and a mockHasher.
  - Happy-path test now asserts hash() was called with the plain password and the entity's passwordHash matches the hashed value.

## Architecture note

The User entity and UserRepository are untouched  they only ever deal with passwordHash. Hashing is purely a use case responsibility, which is where Clean Architecture places it. Swapping cryptjs for Argon2 in the future only requires a new adapter class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User passwords are now securely hashed during registration, protecting accounts with industry-standard encryption.
  * Plain-text passwords are automatically converted to secure hashes before storage, ensuring sensitive data protection.

* **Chores**
  * Added cryptographic dependencies to support secure password handling and storage in user registration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->